### PR TITLE
Fix PokéWare session models and views

### DIFF
--- a/PokemonTeam/Controllers/PokeWareController.cs
+++ b/PokemonTeam/Controllers/PokeWareController.cs
@@ -216,7 +216,6 @@ public class PokeWareController : Controller
     private async Task<string> UseObjectAsync(int objectId, PokeWareSession session)
     {
         var playerObj = await _context.Items
-                                      .Include(po => po.Name)
                                       .FirstOrDefaultAsync(po => po.Id == objectId);
         if (playerObj is null) return "Objet inconnu";
 

--- a/PokemonTeam/Models/PokeWare/PokeWareSession.cs
+++ b/PokemonTeam/Models/PokeWare/PokeWareSession.cs
@@ -30,6 +30,11 @@ public class PokeWareSession
     public int PokeDollarsEarned { get; set; }
 
     /// <summary>
+    /// Nombre total de questions du quiz.
+    /// </summary>
+    public int TotalQuestions => Questions.Count;
+
+    /// <summary>
     /// Retourne <c>true</c> lorsque le joueur n’a plus de vie
     /// ou que toutes les questions ont été posées.
     /// </summary>

--- a/PokemonTeam/Views/PokeWare/Question.cshtml
+++ b/PokemonTeam/Views/PokeWare/Question.cshtml
@@ -3,7 +3,7 @@
 @{
     ViewData["Title"] = "Question du Quiz";
     Layout = "~/Views/Shared/_Layout.cshtml";
-    var session = HttpContext.Session.GetObject<PokeWareSession>("PokeWareSession");
+    var session = HttpContext.Session.GetObject<PokeWareSession>("QuizSession");
     var currentQuestion = (session?.CurrentQuestionIndex + 1) ?? 1;
     var totalQuestions = session?.TotalQuestions ?? 0;
 }

--- a/PokemonTeam/Views/PokeWare/Shop.cshtml
+++ b/PokemonTeam/Views/PokeWare/Shop.cshtml
@@ -1,4 +1,4 @@
-﻿@model List<ObjectItem>
+﻿@model List<Item>
 
 @{
     ViewData["Title"] = "Boutique - Objets à utiliser";


### PR DESCRIPTION
## Summary
- add `TotalQuestions` computed property to `PokeWareSession`
- correct session key usage in `Question` view
- expect `Item` model for shop view
- fix `UseObjectAsync` query

## Testing
- `dotnet test PokemonTeam.sln` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce78ebbe08325ae5a4d776c31db50