### PR TITLE
Fix Razor css and add Name alias

### DIFF
--- a/PokemonTeam/Models/TypeChart.cs
+++ b/PokemonTeam/Models/TypeChart.cs
@@ -36,6 +36,9 @@ public class TypeChart
     
     public int id { get; private set; }
     public string typeName { get; private set; }
+    // Some views or services expect a property named "Name". Expose an alias
+    // that maps to <see cref="typeName"/> to avoid compile errors.
+    public string Name => typeName;
     
     public decimal fire { get; private set; }
     

--- a/PokemonTeam/Views/PokeWare/Result.cshtml
+++ b/PokemonTeam/Views/PokeWare/Result.cshtml
@@ -143,7 +143,7 @@
         animation: bounce 1s infinite;
     }
 
-    @keyframes bounce {
+    @@keyframes bounce {
         0%, 20%, 50%, 80%, 100%
 
     {
@@ -166,7 +166,7 @@
         animation: pulse 2s infinite;
     }
 
-    @keyframes pulse {
+    @@keyframes pulse {
         0%, 100%
 
     {

--- a/PokemonTeam/Views/PokeWare/SelectMode.cshtml
+++ b/PokemonTeam/Views/PokeWare/SelectMode.cshtml
@@ -223,7 +223,7 @@
             animation-delay: 0.4s;
         }
 
-    @keyframes slideInUp {
+    @@keyframes slideInUp {
         to
 
     {
@@ -234,7 +234,7 @@
     }
 
     /* Responsive */
-    @media (max-width: 768px) {
+    @@media (max-width: 768px) {
         .display-4
 
     {

--- a/PokemonTeam/Views/PokeWare/Shop.cshtml
+++ b/PokemonTeam/Views/PokeWare/Shop.cshtml
@@ -259,7 +259,7 @@
             animation-delay: 0.6s;
         }
 
-    @keyframes slideInUp {
+    @@keyframes slideInUp {
         to
 
     {
@@ -269,7 +269,7 @@
 
     }
 
-    @media (max-width: 768px) {
+    @@media (max-width: 768px) {
         .item-icon
 
     {


### PR DESCRIPTION
## Summary
- fix Razor style directives using @@ escape sequences
- expose `TypeChart.Name` alias for `typeName` to avoid compile errors

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1bfe36d08325aca9ace1434c42e9