### PR TITLE
Fix session access in quiz view

### DIFF
--- a/PokemonTeam/Views/PokeWare/Question.cshtml
+++ b/PokemonTeam/Views/PokeWare/Question.cshtml
@@ -3,7 +3,9 @@
 @{
     ViewData["Title"] = "Question du Quiz";
     Layout = "~/Views/Shared/_Layout.cshtml";
-    var session = HttpContext.Session.GetObject<PokeWareSession>("QuizSession");
+    // HttpContext isn't available as a static property inside Razor views.
+    // Use the view context's HttpContext instance to access the session.
+    var session = Context.Session.GetObject<PokeWareSession>("QuizSession");
     var currentQuestion = (session?.CurrentQuestionIndex + 1) ?? 1;
     var totalQuestions = session?.TotalQuestions ?? 0;
 }


### PR DESCRIPTION
## Summary
- access Session via the context in Question.cshtml

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1ef45bb08325b3dd8b3a38de5ee2