### PR TITLE
Fix PokeWare link on home page

### DIFF
--- a/PokemonTeam/Controllers/PokeWareController.cs
+++ b/PokemonTeam/Controllers/PokeWareController.cs
@@ -39,9 +39,19 @@ public class PokeWareController : Controller
     {
         var player = await GetCurrentPlayer(includePokemons: true);
 
-        if (player == null) return RedirectToAction("Index", "Home");
+        List<Pokemon> pokemons;
+        if (player == null)
+        {
+            // Fallback : afficher tous les Pokémon si aucun joueur connecté
+            pokemons = await _context.Pokemons
+                .Include(p => p.Types)
+                .ToListAsync();
+        }
+        else
+        {
+            pokemons = player.Pokemons;
+        }
 
-        var pokemons = player.Pokemons;
         return View(pokemons);
     }
 

--- a/PokemonTeam/Views/Home/Index.cshtml
+++ b/PokemonTeam/Views/Home/Index.cshtml
@@ -1,8 +1,41 @@
-﻿@{
-    ViewData["Title"] = "Home Page";
+@{
+    ViewData["Title"] = "Accueil";
 }
 
-<div class="text-center">
-    <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+<div class="container text-center mt-4">
+    <h1 class="display-4">Bienvenue</h1>
+    <p>Sélectionne une application pour commencer :</p>
+
+    <div class="row mt-5">
+        <div class="col-md-4 mb-4">
+            <div class="card h-100">
+                <div class="card-body d-flex flex-column justify-content-center">
+                    <h5 class="card-title">PariPoke</h5>
+                    <p class="card-text">Parie sur la course Pokémon</p>
+                    <a asp-controller="PariPoke" asp-action="Index" class="btn btn-primary mt-auto">Accéder</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-4 mb-4">
+            <div class="card h-100">
+                <div class="card-body d-flex flex-column justify-content-center">
+                    <h5 class="card-title">PokeGacha</h5>
+                    <p class="card-text">Tire des Pokémon et combats</p>
+                    <a asp-controller="PokeGacha" asp-action="Index" class="btn btn-primary mt-auto">Accéder</a>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-4 mb-4">
+            <div class="card h-100">
+                <div class="card-body d-flex flex-column justify-content-center">
+                    <h5 class="card-title">PokeWare</h5>
+                    <p class="card-text">Quiz Pokémon interactif</p>
+                    <a asp-controller="PokeWare" asp-action="SelectTeam" class="btn btn-primary mt-auto">Accéder</a>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
+

--- a/PokemonTeam/Views/PokeWare/SelectMode.cshtml
+++ b/PokemonTeam/Views/PokeWare/SelectMode.cshtml
@@ -148,7 +148,7 @@
 
             <!-- Navigation -->
             <div class="text-center">
-                <a href="@Url.Action("SelectTeam", "Quiz")" class="btn btn-outline-secondary btn-lg">
+                <a asp-controller="PokeWare" asp-action="SelectTeam" class="btn btn-outline-secondary btn-lg">
                     <i class="fas fa-arrow-left"></i> Revenir à la sélection des Pokémon
                 </a>
             </div>


### PR DESCRIPTION
## Summary
- adjust SelectTeam so page is accessible even without a player
- fix SelectMode link back to SelectTeam

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d204c87fc8325a62ff3769d3bcd93