### PR TITLE
Implement PokeAPI quiz with visual lives

### DIFF
--- a/PokemonTeam/Controllers/PokeWareController.cs
+++ b/PokemonTeam/Controllers/PokeWareController.cs
@@ -2,8 +2,10 @@
 using Microsoft.EntityFrameworkCore;
 using PokemonTeam.Data;      // injecte PokemonDbContext
 using PokemonTeam.Models;     // Pokemon
-using PokemonTeam.Models.PokeWare;    // Pokemon, PokeWareQuestion, PokeWareSession
+using PokemonTeam.Models.PokeWare;
+using PokemonTeam.Services;    // Pokemon, PokeWareQuestion, PokeWareSession
 using System.Security.Claims;
+using System.Threading.Tasks;
 
 namespace PokemonTeam.Controllers;
 /// <summary>
@@ -24,12 +26,14 @@ public class PokeWareController : Controller
 {
     private readonly PokemonDbContext _context;
     private readonly PokemonController _pokemonController;
+    private readonly PokeApiService _pokeApi;
     private readonly Random _rng = new();
 
-    public PokeWareController(PokemonDbContext context)
+    public PokeWareController(PokemonDbContext context, PokeApiService pokeApi)
     {
         _context = context;
         _pokemonController = new PokemonController(context);
+        _pokeApi = pokeApi;
     }
 
     // --------------------------------------------------------------------
@@ -94,7 +98,7 @@ public class PokeWareController : Controller
     public IActionResult SelectMode() => View();   // options : 10 / 20 / 50 / Infini
 
     [HttpPost]
-    public IActionResult StartQuiz(int numberOfQuestions)
+    public async Task<IActionResult> StartQuiz(int numberOfQuestions)
     {
         var session = HttpContext.Session.GetObject<PokeWareSession>("QuizSession");
         if (session is null)
@@ -112,7 +116,7 @@ public class PokeWareController : Controller
             return RedirectToAction(nameof(SelectMode));
         }
 
-        session.Questions = GenerateQuiz(session.Pokemons, numberOfQuestions);
+        session.Questions = await GenerateQuizAsync(session.Pokemons, numberOfQuestions);
         session.CurrentQuestionIndex = 0;
         HttpContext.Session.SetObject("QuizSession", session);
 
@@ -222,26 +226,49 @@ public class PokeWareController : Controller
     }
 
     /// <summary>
-    /// Construit une liste de questions à partir de la team.
+    /// Construit une liste de questions aléatoires.
     /// </summary>
-    private List<PokeWareQuestion> GenerateQuiz(List<Pokemon> team, int count)
+    private async Task<List<PokeWareQuestion>> GenerateQuizAsync(List<Pokemon> team, int count)
     {
         if (team == null || team.Count == 0 || count <= 0)
             return new List<PokeWareQuestion>();
 
         var quiz = new List<PokeWareQuestion>(count);
+        var allTypes = new[] { "fire", "water", "grass", "electric", "ice", "fighting", "poison", "ground", "flying", "psychic", "bug", "rock", "ghost", "dragon", "dark", "steel", "fairy", "normal" };
+
         for (int i = 0; i < count; i++)
         {
-            var poke = team[_rng.Next(team.Count)];
-            string pokeType = poke.Types.Any()
-                ? poke.Types[_rng.Next(poke.Types.Count)].Name
-                : "Inconnu";
-            quiz.Add(new PokeWareQuestion
+            if (_rng.Next(2) == 0)
             {
-                QuestionText = $"Quel est le type élémentaire de {poke.name} ?",
-                CorrectAnswer = pokeType,
-                Choices = new List<string> { pokeType }
-            });
+                var poke = team[_rng.Next(team.Count)];
+                string correct = poke.Types.Any()
+                    ? poke.Types[_rng.Next(poke.Types.Count)].Name
+                    : "normal";
+                var choices = new HashSet<string> { correct };
+                while (choices.Count < 4)
+                {
+                    var candidate = allTypes[_rng.Next(allTypes.Length)];
+                    choices.Add(candidate);
+                }
+
+                quiz.Add(new PokeWareQuestion
+                {
+                    QuestionText = $"Quel est le type élémentaire de {poke.name} ?",
+                    CorrectAnswer = correct,
+                    Choices = choices.OrderBy(_ => _rng.Next()).ToList()
+                });
+            }
+            else
+            {
+                var (name, image) = await _pokeApi.GetRandomPokemonAsync();
+                quiz.Add(new PokeWareQuestion
+                {
+                    QuestionText = "Quel est ce Pokémon ?",
+                    ImageUrl = image,
+                    CorrectAnswer = name,
+                    Choices = new List<string>()
+                });
+            }
         }
         return quiz;
     }

--- a/PokemonTeam/Program.cs
+++ b/PokemonTeam/Program.cs
@@ -8,17 +8,18 @@ using PokemonTeam.Models;
 using PokemonTeam.Services;
 
 var builder = WebApplication.CreateBuilder(args);
-// Pour stocker l'état du quiz en session mémoire
+builder.Services.AddHttpClient<PokeApiService>();
+// Pour stocker l'Ã©tat du quiz en session mÃ©moire
 builder.Services.AddDistributedMemoryCache();
 builder.Services.AddSession(options =>
 {
     options.Cookie.HttpOnly = true;
     options.Cookie.IsEssential = true;
-    // durée de session par défaut
+    // durÃ©e de session par dÃ©faut
     options.IdleTimeout = TimeSpan.FromMinutes(30);
 });
 
-// Permet l’injection de IHttpContextAccessor dans vos contrôleurs
+// Permet lâ€™injection de IHttpContextAccessor dans vos contrÃ´leurs
 builder.Services.AddHttpContextAccessor();
 // Add services to the container.
 builder.Services.AddControllersWithViews();

--- a/PokemonTeam/Services/PokeApiService.cs
+++ b/PokemonTeam/Services/PokeApiService.cs
@@ -1,0 +1,36 @@
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+
+namespace PokemonTeam.Services;
+
+public class PokeApiService
+{
+    private readonly HttpClient _httpClient;
+    private readonly Random _rng = new();
+
+    public PokeApiService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task<(string name, string imageUrl)> GetRandomPokemonAsync()
+    {
+        int id = _rng.Next(1, 152); // first generation range
+        var data = await _httpClient.GetFromJsonAsync<PokeApiPokemon>($"https://pokeapi.co/api/v2/pokemon/{id}");
+        string image = data?.sprites?.front_default ??
+                       $"https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/{id}.png";
+        return (data?.name ?? $"pokemon{id}", image);
+    }
+
+    private class PokeApiPokemon
+    {
+        public string name { get; set; } = "";
+        public Sprite sprites { get; set; } = new();
+    }
+
+    private class Sprite
+    {
+        public string front_default { get; set; } = "";
+    }
+}

--- a/PokemonTeam/Views/PokeWare/Question.cshtml
+++ b/PokemonTeam/Views/PokeWare/Question.cshtml
@@ -72,9 +72,8 @@
                             }
                             else
                             {
-                                <div class="alert alert-warning text-center">
-                                    <i class="fas fa-exclamation-triangle"></i> Aucune réponse disponible
-                                </div>
+                                <input type="text" class="form-control" name="userAnswer" placeholder="Entre ton choix" required />
+                                <button type="submit" class="btn btn-primary mt-2">Valider</button>
                             }
                         </div>
                     </form>
@@ -91,7 +90,14 @@
                                 <strong>Score:</strong> @session.Score
                             </div>
                             <div class="col-md-3">
-                                <strong>Vies:</strong> @session.LivesLeft ❤️
+                                <strong>Vies:</strong>
+                                <div class="d-flex justify-content-center mt-1">
+                                    @for (int i = 0; i < session.Pokemons.Count; i++)
+                                    {
+                                        var alive = i < session.LivesLeft;
+                                        <img class="life-pokemon @(alive ? "life-alive" : "life-dead")" src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/@session.Pokemons[i].Id.png" />
+                                    }
+                                </div>
                             </div>
                             <div class="col-md-3">
                                 <strong>Pokédollars:</strong> @session.PokeDollarsEarned 💰

--- a/PokemonTeam/wwwroot/css/PokeWare.css
+++ b/PokemonTeam/wwwroot/css/PokeWare.css
@@ -1,0 +1,20 @@
+.life-pokemon {
+    width: 40px;
+    height: 40px;
+    margin: 0 4px;
+}
+
+.life-alive {
+    animation: bounce 1s infinite;
+}
+
+.life-dead {
+    filter: grayscale(100%);
+    animation: none;
+    opacity: 0.5;
+}
+
+@keyframes bounce {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-10px); }
+}


### PR DESCRIPTION
## Summary
- add a PokeApi service for fetching pokemon info
- generate quiz questions asynchronously with random images or type questions
- display team sprites as bouncing lives
- allow text answer when no choices are present
- add dedicated css for quiz visuals
- register the new service

## Testing
- `dotnet test PokemonTeam.sln -v minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d3e85d5008325a76a11dd367c576c