### PR TITLE
Fix Pokedollar balance mismatch

### DIFF
--- a/PokemonTeam/Controllers/PokeWareController.cs
+++ b/PokemonTeam/Controllers/PokeWareController.cs
@@ -122,11 +122,14 @@ public class PokeWareController : Controller
     // --------------------------------------------------------------------
     // 3. Affichage et soumission d’une question
     // --------------------------------------------------------------------
-    public IActionResult Question()
+    public async Task<IActionResult> Question()
     {
         var session = HttpContext.Session.GetObject<PokeWareSession>("QuizSession");
         if (session is null || session.IsOver)
             return RedirectToAction(nameof(Result));
+
+        var player = await GetCurrentPlayer();
+        ViewBag.TotalPokedollars = (player?.Pokedollar ?? 0) + session.PokeDollarsEarned;
 
         return View(session.CurrentQuestion);
     }
@@ -186,9 +189,60 @@ public class PokeWareController : Controller
     }
 
     // --------------------------------------------------------------------
+    // 4b. Boutique d'achat d'objets
+    // --------------------------------------------------------------------
+    public async Task<IActionResult> Store()
+    {
+        var items = await _context.Items.ToListAsync();
+        var player = await GetCurrentPlayer(includeItems: true);
+        var session = HttpContext.Session.GetObject<PokeWareSession>("QuizSession");
+
+        if (player != null && session != null)
+            await SyncPokedollars(player, session);
+
+        ViewBag.Pokedollars = player?.Pokedollar ?? 0;
+        return View(items);
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> BuyItem(int itemId)
+    {
+        var player = await GetCurrentPlayer(includeItems: true);
+        var session = HttpContext.Session.GetObject<PokeWareSession>("QuizSession");
+        if (player == null)
+            return RedirectToAction(nameof(SelectTeam));
+
+        if (session != null)
+            await SyncPokedollars(player, session);
+
+        var item = await _context.Items.FirstOrDefaultAsync(i => i.Id == itemId);
+        if (item == null)
+        {
+            TempData["Error"] = "Objet introuvable.";
+            return RedirectToAction(nameof(Store));
+        }
+
+        if (player.Pokedollar < item.Price)
+        {
+            TempData["Error"] = "Pokédollars insuffisants.";
+            return RedirectToAction(nameof(Store));
+        }
+
+        if (!player.Items.Any(i => i.Id == item.Id))
+            player.Items.Add(item);
+
+        player.Pokedollar -= item.Price;
+        await _context.SaveChangesAsync();
+
+        TempData["Message"] = $"{item.Name} acheté !";
+        return RedirectToAction(nameof(Store));
+    }
+
+    // --------------------------------------------------------------------
     // 5. Résultat final
     // --------------------------------------------------------------------
-    public IActionResult Result()
+    public async Task<IActionResult> Result()
     {
         var session = HttpContext.Session.GetObject<PokeWareSession>("QuizSession");
         if (session is null)
@@ -197,9 +251,14 @@ public class PokeWareController : Controller
         int bonus = session.LivesLeft * 10;
         session.Score += bonus;
 
+        int earned = session.PokeDollarsEarned;
+        var player = await GetCurrentPlayer();
+        if (player != null)
+            await SyncPokedollars(player, session);
+
         ViewBag.FinalScore = session.Score;
         ViewBag.Bonus = bonus;
-        ViewBag.PokeDollars = session.PokeDollarsEarned;
+        ViewBag.PokeDollars = earned;
         return View();
     }
 
@@ -285,5 +344,19 @@ public class PokeWareController : Controller
         player.Items.Remove(playerObj);
         await _context.SaveChangesAsync();
         return playerObj.Name;
+    }
+
+    /// <summary>
+    /// Synchronise les Pokédollars gagnés pendant la partie avec le joueur.
+    /// </summary>
+    private async Task SyncPokedollars(Player player, PokeWareSession session)
+    {
+        if (session.PokeDollarsEarned > 0)
+        {
+            player.Pokedollar += session.PokeDollarsEarned;
+            session.PokeDollarsEarned = 0;
+            HttpContext.Session.SetObject("QuizSession", session);
+            await _context.SaveChangesAsync();
+        }
     }
 }

--- a/PokemonTeam/Views/PokeWare/Question.cshtml
+++ b/PokemonTeam/Views/PokeWare/Question.cshtml
@@ -8,6 +8,7 @@
     var session = Context.Session.GetObject<PokeWareSession>("QuizSession");
     var currentQuestion = (session?.CurrentQuestionIndex + 1) ?? 1;
     var totalQuestions = session?.TotalQuestions ?? 0;
+    var totalPokeDollars = ViewBag.TotalPokedollars ?? (session?.PokeDollarsEarned ?? 0);
 }
 
 <div class="container mt-4">
@@ -94,10 +95,10 @@
                                 <strong>Vies:</strong> @session.LivesLeft ❤️
                             </div>
                             <div class="col-md-3">
-                                <strong>Pokédollars:</strong> @session.PokeDollarsEarned 💰
+                                <strong>Pokédollars:</strong> @totalPokeDollars 💰
                             </div>
                             <div class="col-md-3">
-                                <a class="btn btn-sm btn-secondary" asp-action="Shop">
+                                <a class="btn btn-sm btn-secondary" asp-action="Store">
                                     <i class="fas fa-shopping-cart"></i> Boutique
                                 </a>
                             </div>

--- a/PokemonTeam/Views/PokeWare/Result.cshtml
+++ b/PokemonTeam/Views/PokeWare/Result.cshtml
@@ -110,7 +110,7 @@
                     <a class="btn btn-primary btn-lg" asp-action="SelectTeam">
                         <i class="fas fa-redo"></i> Rejouer
                     </a>
-                    <a class="btn btn-success btn-lg" asp-action="Shop">
+                    <a class="btn btn-success btn-lg" asp-action="Store">
                         <i class="fas fa-shopping-cart"></i> Visiter la boutique
                     </a>
                     <a class="btn btn-outline-secondary btn-lg" href="/">

--- a/PokemonTeam/Views/PokeWare/Store.cshtml
+++ b/PokemonTeam/Views/PokeWare/Store.cshtml
@@ -1,0 +1,61 @@
+@using PokemonTeam.Models
+@model List<Item>
+@{
+    ViewData["Title"] = "Boutique";
+    Layout = "~/Views/Shared/_Layout.cshtml";
+    int balance = ViewBag.Pokedollars ?? 0;
+}
+
+<div class="container mt-4">
+    <h2 class="mb-3 text-center">Boutique</h2>
+    <p class="text-center">Solde : <strong>@balance</strong> Pokédollars</p>
+
+    @if (TempData["Message"] != null)
+    {
+        <div class="alert alert-success">@TempData["Message"]</div>
+    }
+    @if (TempData["Error"] != null)
+    {
+        <div class="alert alert-danger">@TempData["Error"]</div>
+    }
+
+    <div class="row">
+        @foreach (var item in Model)
+        {
+            <div class="col-md-6 col-lg-4 mb-4">
+                <div class="card h-100">
+                    <div class="card-header">
+                        <strong>@item.Name</strong> - @item.Price Pokédollars
+                    </div>
+                    <div class="card-body">
+                        <p>@GetItemDescription(item.Name)</p>
+                        <form asp-action="BuyItem" method="post">
+                            <input type="hidden" name="itemId" value="@item.Id" />
+                            <button type="submit" class="btn btn-primary" @(balance >= item.Price ? "" : "disabled")>
+                                Acheter
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+
+    <div class="text-center mt-3">
+        <a class="btn btn-secondary" asp-action="Question">Retour au quiz</a>
+    </div>
+</div>
+
+@functions{
+    private string GetItemDescription(string name)
+    {
+        return name switch
+        {
+            "Potion" => "Restaure l'une de tes vies.",
+            "Super Potion" => "Ajoute 10 points à ton score.",
+            "Hyper Potion" => "Ajoute 20 points à ton score.",
+            "Max Potion" => "Restaure toutes tes vies.",
+            _ => "Objet mystérieux"
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- sync quiz display with player's Pokedollar balance
- preserve earned amount on results screen

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3cf4caf48325972be0db62cc2b3a