### PR TITLE
Use item immediately after purchase

### DIFF
--- a/PokemonTeam/Controllers/PokeWareController.cs
+++ b/PokemonTeam/Controllers/PokeWareController.cs
@@ -243,6 +243,14 @@ public class PokeWareController : Controller
         player.Pokedollar -= item.Price;
         await _context.SaveChangesAsync();
 
+        if (session != null)
+        {
+            string effect = await UseObjectAsync(itemId, session);
+            HttpContext.Session.SetObject("QuizSession", session);
+            TempData["Message"] = $"{item.Name} acheté et utilisé : {effect}";
+            return RedirectToAction(nameof(Question));
+        }
+
         TempData["Message"] = $"{item.Name} acheté !";
         return RedirectToAction(nameof(Store));
     }


### PR DESCRIPTION
## Summary
- improve Store BuyItem behaviour so purchasing an item uses it instantly

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4f151f8c8325aa766da828448237