### PR TITLE
Fix redirect when buying without player

### DIFF
--- a/PokemonTeam/Controllers/PokeWareController.cs
+++ b/PokemonTeam/Controllers/PokeWareController.cs
@@ -218,7 +218,10 @@ public class PokeWareController : Controller
 
         var session = HttpContext.Session.GetObject<PokeWareSession>("QuizSession");
         if (player == null)
-            return RedirectToAction(nameof(SelectTeam));
+        {
+            TempData["Error"] = "Joueur non connecté.";
+            return RedirectToAction(nameof(Store));
+        }
 
         if (session != null)
             await SyncPokedollars(player, session);


### PR DESCRIPTION
## Summary
- fix store purchase redirect when player is missing

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d521d05388325ba3950f0b9b54718