### PR TITLE
Make team selection cards wider and clickable

### DIFF
--- a/PokemonTeam/Views/PokeWare/SelectTeam.cshtml
+++ b/PokemonTeam/Views/PokeWare/SelectTeam.cshtml
@@ -32,7 +32,7 @@
                 <div class="row g-3">
                     @for (int i = 0; i < Model.Count; i++)
                     {
-                        <div class="col-md-6 col-lg-4">
+                        <div class="col-md-6 col-lg-6">
                             <div class="card h-100 pokemon-card" data-pokemon-id="@Model[i].Id">
                                 <div class="card-body d-flex flex-column">
                                     <h5 class="card-title text-center mb-3">
@@ -45,31 +45,6 @@
                                              alt="@Model[i].name" />
                                     </div>
 
-                                    <div class="pokemon-stats mb-3 flex-grow-1">
-                                        <div class="row text-center">
-                                            <div class="col-4">
-                                                <div class="stat-item">
-                                                    <i class="fas fa-heart text-danger"></i>
-                                                    <div class="stat-value">@Model[i].healthPoint</div>
-                                                    <small class="text-muted">PV</small>
-                                                </div>
-                                            </div>
-                                            <div class="col-4">
-                                                <div class="stat-item">
-                                                    <i class="fas fa-fist-raised text-warning"></i>
-                                                    <div class="stat-value">@Model[i].strength</div>
-                                                    <small class="text-muted">Force</small>
-                                                </div>
-                                            </div>
-                                            <div class="col-4">
-                                                <div class="stat-item">
-                                                    <i class="fas fa-bolt text-success"></i>
-                                                    <div class="stat-value">@Model[i].speed</div>
-                                                    <small class="text-muted">Vitesse</small>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
 
                                     <div class="form-check form-switch d-flex justify-content-center">
                                         <input class="form-check-input pokemon-checkbox"
@@ -117,15 +92,6 @@
                 background-color: #f8f9ff;
             }
 
-        .stat-item {
-            padding: 0.5rem;
-        }
-
-        .stat-value {
-            font-size: 1.2rem;
-            font-weight: bold;
-            margin: 0.25rem 0;
-        }
 
         .pokemon-image {
             width: 96px;
@@ -199,6 +165,18 @@
                     }
 
                     updateUI();
+                });
+            });
+
+            // Rendre toute la carte cliquable
+            document.querySelectorAll('.pokemon-card').forEach(card => {
+                card.addEventListener('click', function(e) {
+                    if (e.target.tagName.toLowerCase() === 'label' || e.target.classList.contains('pokemon-checkbox')) {
+                        return;
+                    }
+                    const checkbox = card.querySelector('.pokemon-checkbox');
+                    checkbox.checked = !checkbox.checked;
+                    checkbox.dispatchEvent(new Event('change'));
                 });
             });
 


### PR DESCRIPTION
## Summary
- widen team selection cards
- remove PV/Force/Vitesse display
- allow clicking anywhere on card to select Pokémon

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d5d5080548325a8a192c7d1cce457