### PR TITLE
Reduce spacing between runner cards

### DIFF
--- a/PokemonTeam/wwwroot/css/PariPoke.css
+++ b/PokemonTeam/wwwroot/css/PariPoke.css
@@ -206,7 +206,7 @@
 #runnersSelection {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-    gap: 12px;
+    gap: 6px;
     max-height: 400px;
     overflow-y: auto;
     padding: 10px;


### PR DESCRIPTION
## Summary
- adjust layout for runners selection to use smaller gap so cards sit closer together

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d613058d083259acbe26bc16803af