### PR TITLE
Reduce spacing between team selection cards

### DIFF
--- a/PokemonTeam/Views/PokeWare/SelectTeam.cshtml
+++ b/PokemonTeam/Views/PokeWare/SelectTeam.cshtml
@@ -29,7 +29,7 @@
                     </div>
                 </div>
 
-                <div class="row g-3">
+                <div class="row g-2">
                     @for (int i = 0; i < Model.Count; i++)
                     {
                         <div class="col-md-6 col-lg-6">


### PR DESCRIPTION
## Summary
- tighten card gaps on the team selection page

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6276ea088325819955750c49f708