### PR TITLE
Fix PokéWare question rendering

### DIFF
--- a/PokemonTeam/Controllers/PokeWareController.cs
+++ b/PokemonTeam/Controllers/PokeWareController.cs
@@ -330,6 +330,7 @@ public class PokeWareController : Controller
                 quiz.Add(new PokeWareQuestion
                 {
                     QuestionText = $"Quel est le type élémentaire de {poke.name} ?",
+                    ImageUrl = null, // ensure text questions have no image
                     CorrectAnswer = correct,
                     Choices = choices.OrderBy(_ => _rng.Next()).ToList()
                 });

--- a/PokemonTeam/Models/Pokemon.cs
+++ b/PokemonTeam/Models/Pokemon.cs
@@ -52,6 +52,11 @@ public class Pokemon
 
     [Column("name")]
     public string name { get; private set; }
+
+    // Some views or services expect a property named "Name". Expose an alias
+    // that maps to <see cref="name"/> to avoid null values when the code uses
+    // the capitalized property.
+    public string Name => name;
     
 
     [Column("health_point")]

--- a/PokemonTeam/Views/PokeWare/Question.cshtml
+++ b/PokemonTeam/Views/PokeWare/Question.cshtml
@@ -65,8 +65,7 @@
                                     <button type="submit"
                                             name="userAnswer"
                                             value="@choice"
-                                            class="btn btn-outline-primary btn-lg answer-btn"
-                                            onclick="this.form.submit(); this.disabled=true;">
+                                            class="btn btn-outline-primary btn-lg answer-btn">
                                         @choice
                                     </button>
                                 }


### PR DESCRIPTION
## Summary
- alias `Pokemon.Name` property so quiz text interpolation works
- ensure no leftover image URL on text questions
- submit quiz answers via standard form post

## Testing
- `dotnet test PokemonTeam.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d64fd9ab483259926f9c421b390e1