### PR TITLE
Add skip question via special bouncing pokemon

### DIFF
--- a/PokemonTeam/Controllers/PokeWareController.cs
+++ b/PokemonTeam/Controllers/PokeWareController.cs
@@ -165,6 +165,31 @@ public class PokeWareController : Controller
         return RedirectToAction(nameof(Question));
     }
 
+    /// <summary>
+    /// Skip the current question when the special bouncing Pokémon is clicked.
+    /// </summary>
+    [HttpPost]
+    public IActionResult SkipQuestion()
+    {
+        var session = HttpContext.Session.GetObject<PokeWareSession>("QuizSession");
+        if (session is null)
+        {
+            return Json(new { redirect = Url.Action(nameof(SelectTeam)) });
+        }
+
+        if (!session.IsOver)
+            session.CurrentQuestionIndex++;
+
+        HttpContext.Session.SetObject("QuizSession", session);
+
+        if (session.IsOver)
+        {
+            return Json(new { redirect = Url.Action(nameof(Result)) });
+        }
+
+        return Json(new { redirect = Url.Action(nameof(Question)) });
+    }
+
     // --------------------------------------------------------------------
     // 4. Boutique d’objets
     // --------------------------------------------------------------------

--- a/PokemonTeam/Views/PokeWare/Question.cshtml
+++ b/PokemonTeam/Views/PokeWare/Question.cshtml
@@ -91,7 +91,7 @@
                             </div>
                             <div class="col-md-3">
                                 <strong>Vies:</strong>
-                                <div class="d-flex justify-content-center mt-1">
+                                <div class="d-flex justify-content-center mt-1" id="lifeContainer">
                                     @for (int i = 0; i < session.Pokemons.Count; i++)
                                     {
                                         var alive = i < session.LivesLeft;
@@ -141,5 +141,20 @@
             });
             this.classList.add('btn-primary');
             this.classList.remove('btn-outline-primary');
-        });
-    });</script>
+        });    });
+
+    // Highlight one random life Pokémon and allow skipping the question
+    window.addEventListener('load', () => {
+        const lives = document.querySelectorAll('#lifeContainer .life-alive');
+        if (lives.length === 0) return;
+        const special = lives[Math.floor(Math.random() * lives.length)];
+        special.classList.add('life-special');
+        special.addEventListener('click', () => {
+            fetch('/PokeWare/SkipQuestion', { method: 'POST' })
+                .then(r => r.json())
+                .then(data => {
+                    if (data.redirect) window.location.href = data.redirect;
+                });
+        }, { once: true });
+    });
+</script>

--- a/PokemonTeam/wwwroot/css/PokeWare.css
+++ b/PokemonTeam/wwwroot/css/PokeWare.css
@@ -4,6 +4,11 @@
     margin: 0 4px;
 }
 
+.life-special {
+    cursor: pointer;
+    animation: bounce-special 0.6s infinite;
+}
+
 .life-alive {
     animation: bounce 1s infinite;
 }
@@ -17,4 +22,9 @@
 @keyframes bounce {
     0%, 100% { transform: translateY(0); }
     50% { transform: translateY(-10px); }
+}
+
+@keyframes bounce-special {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-20px); }
 }


### PR DESCRIPTION
## Summary
- enhance PokeWare question logic to allow skipping a question by clicking a highlighted life Pokémon
- style special bouncing Pokémon with new animation
- update quiz page script to choose a random life Pokémon, animate it, and call the new endpoint

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d8352ef188325867190dc72b89e10