### PR TITLE
Add skip question via special bouncing pokemon

### DIFF
--- a/PokemonTeam/Controllers/PokeWareController.cs
+++ b/PokemonTeam/Controllers/PokeWareController.cs
@@ -165,6 +165,31 @@ public class PokeWareController : Controller
         return RedirectToAction(nameof(Question));
     }
 
+    /// <summary>
+    /// Skip the current question when the special bouncing Pokémon is clicked.
+    /// </summary>
+    [HttpPost]
+    public IActionResult SkipQuestion()
+    {
+        var session = HttpContext.Session.GetObject<PokeWareSession>("QuizSession");
+        if (session is null)
+        {
+            return Json(new { redirect = Url.Action(nameof(SelectTeam)) });
+        }
+
+        if (!session.IsOver)
+            session.CurrentQuestionIndex++;
+
+        HttpContext.Session.SetObject("QuizSession", session);
+
+        if (session.IsOver)
+        {
+            return Json(new { redirect = Url.Action(nameof(Result)) });
+        }
+
+        return Json(new { redirect = Url.Action(nameof(Question)) });
+    }
+
     // --------------------------------------------------------------------
     // 4. Boutique d’objets
     // --------------------------------------------------------------------

--- a/PokemonTeam/Views/PokeWare/Question.cshtml
+++ b/PokemonTeam/Views/PokeWare/Question.cshtml
@@ -91,11 +91,12 @@
                             </div>
                             <div class="col-md-3">
                                 <strong>Vies:</strong>
-                                <div class="d-flex justify-content-center mt-1">
+                                <div class="d-flex justify-content-center mt-1" id="lifeContainer">
                                     @for (int i = 0; i < session.Pokemons.Count; i++)
                                     {
                                         var alive = i < session.LivesLeft;
-                                        <img class="life-pokemon @(alive ? "life-alive" : "life-dead")" src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/@(session.Pokemons[i].Id).png" />
+                                        var type = session.Pokemons[i].Types.FirstOrDefault()?.Name?.ToLower() ?? "normal";
+                                        <img class="life-pokemon @(alive ? "life-alive" : "life-dead")" data-type="@type" src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/@(session.Pokemons[i].Id).png" />
                                     }
                                 </div>
                             </div>
@@ -141,5 +142,24 @@
             });
             this.classList.add('btn-primary');
             this.classList.remove('btn-outline-primary');
-        });
-    });</script>
+        });    });
+
+    // Highlight one random life Pokémon and allow skipping the question
+    window.addEventListener('load', () => {
+        const lives = document.querySelectorAll('#lifeContainer .life-alive');
+        if (lives.length === 0) return;
+        const special = lives[Math.floor(Math.random() * lives.length)];
+        special.classList.add('life-special');
+        special.addEventListener('click', () => {
+            const type = special.dataset.type || 'normal';
+            special.classList.add('life-effect', `life-effect-${type}`);
+            setTimeout(() => {
+                fetch('/PokeWare/SkipQuestion', { method: 'POST' })
+                    .then(r => r.json())
+                    .then(data => {
+                        if (data.redirect) window.location.href = data.redirect;
+                    });
+            }, 300);
+        }, { once: true });
+    });
+</script>

--- a/PokemonTeam/wwwroot/css/PokeWare.css
+++ b/PokemonTeam/wwwroot/css/PokeWare.css
@@ -4,6 +4,11 @@
     margin: 0 4px;
 }
 
+.life-special {
+    cursor: pointer;
+    animation: bounce-special 0.6s infinite;
+}
+
 .life-alive {
     animation: bounce 1s infinite;
 }
@@ -14,7 +19,41 @@
     opacity: 0.5;
 }
 
+.life-effect {
+    animation: flash 0.4s ease;
+}
+
+.life-effect-normal { box-shadow: 0 0 20px 5px #A8A77A; }
+.life-effect-fire { box-shadow: 0 0 20px 5px #EE8130; }
+.life-effect-water { box-shadow: 0 0 20px 5px #6390F0; }
+.life-effect-electric { box-shadow: 0 0 20px 5px #F7D02C; }
+.life-effect-grass { box-shadow: 0 0 20px 5px #7AC74C; }
+.life-effect-ice { box-shadow: 0 0 20px 5px #96D9D6; }
+.life-effect-fighting { box-shadow: 0 0 20px 5px #C22E28; }
+.life-effect-poison { box-shadow: 0 0 20px 5px #A33EA1; }
+.life-effect-ground { box-shadow: 0 0 20px 5px #E2BF65; }
+.life-effect-flying { box-shadow: 0 0 20px 5px #A98FF3; }
+.life-effect-psychic { box-shadow: 0 0 20px 5px #F95587; }
+.life-effect-bug { box-shadow: 0 0 20px 5px #A6B91A; }
+.life-effect-rock { box-shadow: 0 0 20px 5px #B6A136; }
+.life-effect-ghost { box-shadow: 0 0 20px 5px #735797; }
+.life-effect-dragon { box-shadow: 0 0 20px 5px #6F35FC; }
+.life-effect-dark { box-shadow: 0 0 20px 5px #705746; }
+.life-effect-steel { box-shadow: 0 0 20px 5px #B7B7CE; }
+.life-effect-fairy { box-shadow: 0 0 20px 5px #D685AD; }
+
 @keyframes bounce {
     0%, 100% { transform: translateY(0); }
     50% { transform: translateY(-10px); }
+}
+
+@keyframes bounce-special {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-20px); }
+}
+
+@keyframes flash {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.2); }
+    100% { transform: scale(1); }
 }


### PR DESCRIPTION
## Summary
- enhance PokeWare question page to color the special bouncing Pokémon based on its element type when clicked
- style type effects in PokeWare.css with colored glows
- apply animated effect and skip logic through updated script

## Testing
- `dotnet test` *(fails: `dotnet` not found)*


------
https://chatgpt.com/codex/tasks/task_e_686d8352ef188325867190dc72b89e10